### PR TITLE
fix https/svcb convert to string needed for terraform

### DIFF
--- a/client_dto_test.go
+++ b/client_dto_test.go
@@ -778,3 +778,16 @@ func TestResourceRecords_AddMeta(t *testing.T) {
 		})
 	}
 }
+
+func TestHttpsSvcbParams(t *testing.T) {
+	r := ResourceRecord{
+		Content: []any{
+			[]any{"alpn", "h3", "h2"},
+			[]any{"no-default-alpn"},
+			[]any{"ipv4hint", "127.0.0.1", "10.0.0.1"},
+			[]any{"port", 1234},
+		},
+	}
+	str := r.ContentToString()
+	assert.Equal(t, `alpn="h3,h2" no-default-alpn ipv4hint=127.0.0.1,10.0.0.1 port=1234`, str)
+}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/G-Core/gcore-dns-sdk-go
 
-go 1.17
+go 1.18
 
 require (
 	github.com/stretchr/testify v1.7.1


### PR DESCRIPTION
proper `convertToString` implementation for HTTPS/SVCB, or terraform will consider same param key-value as different and apply update, without this, array will serialized as `[key value1 value2]` instead of `key=value1,value2` and considered different by terraform 