### PR TITLE
add failover meta type

### DIFF
--- a/client.go
+++ b/client.go
@@ -1,10 +1,12 @@
 package dnssdk
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"log"
 	"net/http"
@@ -372,6 +374,12 @@ func (c *Client) do(ctx context.Context, method, uri string, bodyParams interfac
 		return nil
 	}
 
+	// try read all so we can put breakpoint here
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("read response body: %w", err)
+	}
+
 	// nolint: wrapcheck
-	return json.NewDecoder(resp.Body).Decode(dest)
+	return json.NewDecoder(bytes.NewReader(body)).Decode(dest)
 }

--- a/client.go
+++ b/client.go
@@ -370,14 +370,14 @@ func (c *Client) do(ctx context.Context, method, uri string, bodyParams interfac
 		return e
 	}
 
-	if dest == nil {
-		return nil
-	}
-
 	// try read all so we can put breakpoint here
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("read response body: %w", err)
+	}
+
+	if dest == nil {
+		return nil
 	}
 
 	// nolint: wrapcheck

--- a/client_dto.go
+++ b/client_dto.go
@@ -349,6 +349,7 @@ type FailoverTcpUdpCheck struct {
 	Timeout   uint16 `json:"timeout"`
 	// TCP/UDP only
 	Command *string `json:"command"` // bytes to sent
+	Regexp  *string `json:"regexp,omitempty"`
 }
 
 // FailoverIcmpCheck for failover meta property with protocol=ICMP

--- a/client_dto.go
+++ b/client_dto.go
@@ -36,6 +36,7 @@ type RRSet struct {
 	TTL     int              `json:"ttl"`
 	Records []ResourceRecord `json:"resource_records"`
 	Filters []RecordFilter   `json:"filters"`
+	Meta    map[string]any   `json:"meta"` // this one for failover, not Meta property inside Records
 }
 
 type RRSets struct {

--- a/client_dto.go
+++ b/client_dto.go
@@ -318,6 +318,71 @@ func NewResourceMetaAsn(asn ...uint64) ResourceMeta {
 	}
 }
 
+// NewResourceMetaFailoverFromMap for failover
+func NewResourceMetaFailoverFromMap(failover map[string]any) ResourceMeta {
+	return ResourceMeta{
+		name:  "failover",
+		value: failover,
+	}
+}
+
+// FailoverHttpCheck for failover meta property with protocol=HTTP
+type FailoverHttpCheck struct {
+	Protocol  string `json:"protocol"` // HTTP
+	Port      uint16 `json:"port"`
+	Frequency uint16 `json:"frequency"`
+	Timeout   uint16 `json:"timeout"`
+	// HTTP only
+	Host           *string `json:"host,omitempty"`
+	HttpStatusCode *uint16 `json:"http_status_code,omitempty"` // 100-599
+	Method         *string `json:"method,omitempty"`           // GET, POST, PUT, DELETE, PATCH
+	Regexp         *string `json:"regexp,omitempty"`
+	TLS            bool    `json:"tls"`
+	URL            *string `json:"url,omitempty"` // without / prefix
+}
+
+// FailoverTcpUdpCheck for failover meta property with protocol=TCP|UDP
+type FailoverTcpUdpCheck struct {
+	Protocol  string `json:"protocol"` // TCP or UDP
+	Port      uint16 `json:"port"`
+	Frequency uint16 `json:"frequency"`
+	Timeout   uint16 `json:"timeout"`
+	// TCP/UDP only
+	Command *string `json:"command"` // bytes to sent
+}
+
+// FailoverIcmpCheck for failover meta property with protocol=ICMP
+type FailoverIcmpCheck struct {
+	Protocol  string `json:"protocol"` // ICMP
+	Port      uint16 `json:"port"`
+	Frequency uint16 `json:"frequency"`
+	Timeout   uint16 `json:"timeout"`
+}
+
+// NewResourceMetaFailoverFromHttp for failover
+func NewResourceMetaFailoverFromHttp(failover FailoverHttpCheck) ResourceMeta {
+	return ResourceMeta{
+		name:  "failover",
+		value: failover,
+	}
+}
+
+// NewResourceMetaFailoverFromTcpUdp for TCP/DUP failover
+func NewResourceMetaFailoverFromTcpUdp(failover FailoverTcpUdpCheck) ResourceMeta {
+	return ResourceMeta{
+		name:  "failover",
+		value: failover,
+	}
+}
+
+// NewResourceMetaFailoverFromIcmp for ICMP failover
+func NewResourceMetaFailoverFromIcmp(failover FailoverIcmpCheck) ResourceMeta {
+	return ResourceMeta{
+		name:  "failover",
+		value: failover,
+	}
+}
+
 // NewResourceMetaLatLong for lat long meta
 func NewResourceMetaLatLong(latlong string) ResourceMeta {
 	latlong = strings.TrimLeft(latlong, "(")

--- a/client_dto.go
+++ b/client_dto.go
@@ -333,12 +333,12 @@ type FailoverHttpCheck struct {
 	Frequency uint16 `json:"frequency"`
 	Timeout   uint16 `json:"timeout"`
 	// HTTP only
+	Method         string  `json:"method,omitempty"` // GET, POST, PUT, DELETE, PATCH
+	URL            string  `json:"url,omitempty"`    // without / prefix
 	Host           *string `json:"host,omitempty"`
 	HttpStatusCode *uint16 `json:"http_status_code,omitempty"` // 100-599
-	Method         *string `json:"method,omitempty"`           // GET, POST, PUT, DELETE, PATCH
 	Regexp         *string `json:"regexp,omitempty"`
 	TLS            bool    `json:"tls"`
-	URL            *string `json:"url,omitempty"` // without / prefix
 }
 
 // FailoverTcpUdpCheck for failover meta property with protocol=TCP|UDP


### PR DESCRIPTION
context: [failover beta](https://gcore.com/news/introducing-dns-failover-closed-beta/) feature not exists in sdk

changes:
- added `meta` for failover on `RRSet`, because apparently `failover` it's not on `[]ResourceRecord`'s `meta` but in `RRSet`'s `meta`