### PR TITLE
add other rrset.meta based on api doc

### DIFF
--- a/client_dto.go
+++ b/client_dto.go
@@ -55,75 +55,84 @@ type RRSet struct {
 }
 
 // SetMetaAsn
-func (r *RRSet) SetMetaAsn(asns []int) {
+func (r *RRSet) SetMetaAsn(asns []int) *RRSet {
 	if r.Meta == nil {
 		r.Meta = RRSetMeta{}
 	}
 	r.Meta["asn"] = asns
+	return r
 }
 
 // SetMetaContinents
-func (r *RRSet) SetMetaContinents(continents []string) {
+func (r *RRSet) SetMetaContinents(continents []string) *RRSet {
 	if r.Meta == nil {
 		r.Meta = RRSetMeta{}
 	}
 	r.Meta["continents"] = continents
+	return r
 }
 
 // SetMetaCountries
-func (r *RRSet) SetMetaCountries(countries []string) {
+func (r *RRSet) SetMetaCountries(countries []string) *RRSet {
 	if r.Meta == nil {
 		r.Meta = RRSetMeta{}
 	}
 	r.Meta["countries"] = countries
+	return r
 }
 
 // SetMetaLatLong
-func (r *RRSet) SetMetaLatLong(lat, long float64) {
+func (r *RRSet) SetMetaLatLong(lat, long float64) *RRSet {
 	if r.Meta == nil {
 		r.Meta = RRSetMeta{}
 	}
 	r.Meta["latlong"] = []float64{lat, long}
+	return r
 }
 
 // SetMetaFallback
-func (r *RRSet) SetMetaFallback(fallback bool) {
+func (r *RRSet) SetMetaFallback(fallback bool) *RRSet {
 	if r.Meta == nil {
 		r.Meta = RRSetMeta{}
 	}
 	r.Meta["fallback"] = fallback
+	return r
 }
 
 // SetMetaBackup
-func (r *RRSet) SetMetaBackup(backup bool) string {
+func (r *RRSet) SetMetaBackup(backup bool) *RRSet {
 	if r.Meta == nil {
 		r.Meta = RRSetMeta{}
 	}
 	r.Meta["backup"] = backup
+	return r
 }
 
 // SetMetaNotes
-func (r *RRSet) SetMetaNotes(notes string) string {
+func (r *RRSet) SetMetaNotes(notes string) *RRSet {
 	if r.Meta == nil {
 		r.Meta = RRSetMeta{}
 	}
 	r.Meta["notes"] = notes
+	return r
 }
 
 // SetMetaWeight
-func (r *RRSet) SetMetaWeight(weight float64) string {
+func (r *RRSet) SetMetaWeight(weight float64) *RRSet {
 	if r.Meta == nil {
 		r.Meta = RRSetMeta{}
 	}
 	r.Meta["weight"] = weight
+	return r
 }
 
 // SetMetaIP
-func (r *RRSet) SetMetaIP(ip string) string {
+func (r *RRSet) SetMetaIP(ip string) *RRSet {
 	if r.Meta == nil {
 		r.Meta = RRSetMeta{}
 	}
 	r.Meta["ip"] = ip
+	return r
 }
 
 // NewRRSetMetaFailoverFromMap for failover
@@ -134,11 +143,12 @@ func NewRRSetMetaFailoverFromMap(failover map[string]any) *RRSetMeta {
 }
 
 // SetMetaFailover
-func (r *RRSet) SetMetaFailover(failover map[string]any) string {
+func (r *RRSet) SetMetaFailover(failover map[string]any) *RRSet {
 	if r.Meta == nil {
 		r.Meta = RRSetMeta{}
 	}
 	r.Meta["failover"] = failover
+	return r
 }
 
 // FailoverHttpCheck for failover meta property with protocol=HTTP
@@ -183,11 +193,12 @@ func NewRRSetMetaMetaFailoverFromHttp(failover FailoverHttpCheck) *RRSetMeta {
 }
 
 // SetMetaFailoverHttp for failover
-func (r *RRSet) SetMetaFailoverHttp(check FailoverHttpCheck) {
+func (r *RRSet) SetMetaFailoverHttp(check FailoverHttpCheck) *RRSet {
 	if r.Meta == nil {
 		r.Meta = RRSetMeta{}
 	}
 	r.Meta["failover"] = check
+	return r
 }
 
 // NewRRSetMetaMetaFailoverFromTcpUdp for TCP/DUP failover
@@ -198,11 +209,12 @@ func NewRRSetMetaMetaFailoverFromTcpUdp(failover FailoverTcpUdpCheck) *RRSetMeta
 }
 
 // SetMetaFailoverTcpUdp for TCP/DUP failover
-func (r *RRSet) SetMetaFailoverTcpUdp(check FailoverTcpUdpCheck) {
+func (r *RRSet) SetMetaFailoverTcpUdp(check FailoverTcpUdpCheck) *RRSet {
 	if r.Meta == nil {
 		r.Meta = RRSetMeta{}
 	}
 	r.Meta["failover"] = check
+	return r
 }
 
 // NewRRSetMetaMetaFailoverFromIcmp for ICMP failover
@@ -213,11 +225,12 @@ func NewRRSetMetaMetaFailoverFromIcmp(failover FailoverIcmpCheck) *RRSetMeta {
 }
 
 // SetMetaFailoverIcmp for ICMP failover
-func (r *RRSet) SetMetaFailoverIcmp(check FailoverIcmpCheck) {
+func (r *RRSet) SetMetaFailoverIcmp(check FailoverIcmpCheck) *RRSet {
 	if r.Meta == nil {
 		r.Meta = RRSetMeta{}
 	}
 	r.Meta["failover"] = check
+	return r
 }
 
 type RRSets struct {

--- a/client_dto.go
+++ b/client_dto.go
@@ -30,13 +30,194 @@ type CreateResponse struct {
 	Error string `json:"error,omitempty"`
 }
 
+type RRSetMeta map[string]any
+
 // RRSet dto as part of zone info from API
 type RRSet struct {
 	Type    string           `json:"type"`
 	TTL     int              `json:"ttl"`
 	Records []ResourceRecord `json:"resource_records"`
 	Filters []RecordFilter   `json:"filters"`
-	Meta    map[string]any   `json:"meta"` // this one for failover, not Meta property inside Records
+	Meta    RRSetMeta        `json:"meta"` // this one for failover, not Meta property inside Records
+	// according to https://api.gcore.com/docs/dns#tag/rrsets/operation/CreateRRSet
+	/*
+	   asn (array of int)
+	   continents (array of string)
+	   countries (array of string)
+	   latlong (array of float64, latitude and longitude)
+	   fallback (bool)
+	   backup (bool)
+	   notes (string)
+	   weight (float)
+	   ip (string)
+	   failover (object, beta feature, might be changed in the future) can have fields 10.1. protocol (string, required, HTTP, TCP, UDP, ICMP) 10.2. port (int, required, 1-65535) 10.3. frequency (int, required, in seconds 10-3600) 10.4. timeout (int, required, in seconds 1-10), 10.5. method (string, only for protocol=HTTP) 10.6. command (string, bytes to be sent only for protocol=TCP/UDP) 10.7. url (string, only for protocol=HTTP) 10.8. tls (bool, only for protocol=HTTP) 10.9. regexp (string regex to match, only for non-ICMP) 10.10. http_status_code (int, only for protocol=HTTP) 10.11. host (string, only for protocol=HTTP)
+	*/
+}
+
+// SetMetaAsn
+func (r *RRSet) SetMetaAsn(asns []int) {
+	if r.Meta == nil {
+		r.Meta = RRSetMeta{}
+	}
+	r.Meta["asn"] = asns
+}
+
+// SetMetaContinents
+func (r *RRSet) SetMetaContinents(continents []string) {
+	if r.Meta == nil {
+		r.Meta = RRSetMeta{}
+	}
+	r.Meta["continents"] = continents
+}
+
+// SetMetaCountries
+func (r *RRSet) SetMetaCountries(countries []string) {
+	if r.Meta == nil {
+		r.Meta = RRSetMeta{}
+	}
+	r.Meta["countries"] = countries
+}
+
+// SetMetaLatLong
+func (r *RRSet) SetMetaLatLong(lat, long float64) {
+	if r.Meta == nil {
+		r.Meta = RRSetMeta{}
+	}
+	r.Meta["latlong"] = []float64{lat, long}
+}
+
+// SetMetaFallback
+func (r *RRSet) SetMetaFallback(fallback bool) {
+	if r.Meta == nil {
+		r.Meta = RRSetMeta{}
+	}
+	r.Meta["fallback"] = fallback
+}
+
+// SetMetaBackup
+func (r *RRSet) SetMetaBackup(backup bool) string {
+	if r.Meta == nil {
+		r.Meta = RRSetMeta{}
+	}
+	r.Meta["backup"] = backup
+}
+
+// SetMetaNotes
+func (r *RRSet) SetMetaNotes(notes string) string {
+	if r.Meta == nil {
+		r.Meta = RRSetMeta{}
+	}
+	r.Meta["notes"] = notes
+}
+
+// SetMetaWeight
+func (r *RRSet) SetMetaWeight(weight float64) string {
+	if r.Meta == nil {
+		r.Meta = RRSetMeta{}
+	}
+	r.Meta["weight"] = weight
+}
+
+// SetMetaIP
+func (r *RRSet) SetMetaIP(ip string) string {
+	if r.Meta == nil {
+		r.Meta = RRSetMeta{}
+	}
+	r.Meta["ip"] = ip
+}
+
+// NewRRSetMetaFailoverFromMap for failover
+func NewRRSetMetaFailoverFromMap(failover map[string]any) *RRSetMeta {
+	return &RRSetMeta{
+		"failover": failover,
+	}
+}
+
+// SetMetaFailover
+func (r *RRSet) SetMetaFailover(failover map[string]any) string {
+	if r.Meta == nil {
+		r.Meta = RRSetMeta{}
+	}
+	r.Meta["failover"] = failover
+}
+
+// FailoverHttpCheck for failover meta property with protocol=HTTP
+type FailoverHttpCheck struct {
+	Protocol  string `json:"protocol"` // HTTP
+	Port      uint16 `json:"port"`
+	Frequency uint16 `json:"frequency"`
+	Timeout   uint16 `json:"timeout"`
+	// HTTP only
+	Method         string  `json:"method,omitempty"` // GET, POST, PUT, DELETE, PATCH
+	URL            string  `json:"url,omitempty"`    // without / prefix
+	Host           *string `json:"host,omitempty"`
+	HttpStatusCode *uint16 `json:"http_status_code,omitempty"` // 100-599
+	Regexp         *string `json:"regexp,omitempty"`
+	TLS            bool    `json:"tls"`
+}
+
+// FailoverTcpUdpCheck for failover meta property with protocol=TCP|UDP
+type FailoverTcpUdpCheck struct {
+	Protocol  string `json:"protocol"` // TCP or UDP
+	Port      uint16 `json:"port"`
+	Frequency uint16 `json:"frequency"`
+	Timeout   uint16 `json:"timeout"`
+	// TCP/UDP only
+	Command *string `json:"command"` // bytes to sent
+	Regexp  *string `json:"regexp,omitempty"`
+}
+
+// FailoverIcmpCheck for failover meta property with protocol=ICMP
+type FailoverIcmpCheck struct {
+	Protocol  string `json:"protocol"` // ICMP
+	Port      uint16 `json:"port"`
+	Frequency uint16 `json:"frequency"`
+	Timeout   uint16 `json:"timeout"`
+}
+
+// NewRRSetMetaMetaFailoverFromHttp for failover
+func NewRRSetMetaMetaFailoverFromHttp(failover FailoverHttpCheck) *RRSetMeta {
+	return &RRSetMeta{
+		"failover": failover,
+	}
+}
+
+// SetMetaFailoverHttp for failover
+func (r *RRSet) SetMetaFailoverHttp(check FailoverHttpCheck) {
+	if r.Meta == nil {
+		r.Meta = RRSetMeta{}
+	}
+	r.Meta["failover"] = check
+}
+
+// NewRRSetMetaMetaFailoverFromTcpUdp for TCP/DUP failover
+func NewRRSetMetaMetaFailoverFromTcpUdp(failover FailoverTcpUdpCheck) *RRSetMeta {
+	return &RRSetMeta{
+		"failover": failover,
+	}
+}
+
+// SetMetaFailoverTcpUdp for TCP/DUP failover
+func (r *RRSet) SetMetaFailoverTcpUdp(check FailoverTcpUdpCheck) {
+	if r.Meta == nil {
+		r.Meta = RRSetMeta{}
+	}
+	r.Meta["failover"] = check
+}
+
+// NewRRSetMetaMetaFailoverFromIcmp for ICMP failover
+func NewRRSetMetaMetaFailoverFromIcmp(failover FailoverIcmpCheck) *RRSetMeta {
+	return &RRSetMeta{
+		"failover": failover,
+	}
+}
+
+// SetMetaFailoverIcmp for ICMP failover
+func (r *RRSet) SetMetaFailoverIcmp(check FailoverIcmpCheck) {
+	if r.Meta == nil {
+		r.Meta = RRSetMeta{}
+	}
+	r.Meta["failover"] = check
 }
 
 type RRSets struct {
@@ -316,72 +497,6 @@ func NewResourceMetaAsn(asn ...uint64) ResourceMeta {
 	return ResourceMeta{
 		name:  "asn",
 		value: asn,
-	}
-}
-
-// NewResourceMetaFailoverFromMap for failover
-func NewResourceMetaFailoverFromMap(failover map[string]any) ResourceMeta {
-	return ResourceMeta{
-		name:  "failover",
-		value: failover,
-	}
-}
-
-// FailoverHttpCheck for failover meta property with protocol=HTTP
-type FailoverHttpCheck struct {
-	Protocol  string `json:"protocol"` // HTTP
-	Port      uint16 `json:"port"`
-	Frequency uint16 `json:"frequency"`
-	Timeout   uint16 `json:"timeout"`
-	// HTTP only
-	Method         string  `json:"method,omitempty"` // GET, POST, PUT, DELETE, PATCH
-	URL            string  `json:"url,omitempty"`    // without / prefix
-	Host           *string `json:"host,omitempty"`
-	HttpStatusCode *uint16 `json:"http_status_code,omitempty"` // 100-599
-	Regexp         *string `json:"regexp,omitempty"`
-	TLS            bool    `json:"tls"`
-}
-
-// FailoverTcpUdpCheck for failover meta property with protocol=TCP|UDP
-type FailoverTcpUdpCheck struct {
-	Protocol  string `json:"protocol"` // TCP or UDP
-	Port      uint16 `json:"port"`
-	Frequency uint16 `json:"frequency"`
-	Timeout   uint16 `json:"timeout"`
-	// TCP/UDP only
-	Command *string `json:"command"` // bytes to sent
-	Regexp  *string `json:"regexp,omitempty"`
-}
-
-// FailoverIcmpCheck for failover meta property with protocol=ICMP
-type FailoverIcmpCheck struct {
-	Protocol  string `json:"protocol"` // ICMP
-	Port      uint16 `json:"port"`
-	Frequency uint16 `json:"frequency"`
-	Timeout   uint16 `json:"timeout"`
-}
-
-// NewResourceMetaFailoverFromHttp for failover
-func NewResourceMetaFailoverFromHttp(failover FailoverHttpCheck) ResourceMeta {
-	return ResourceMeta{
-		name:  "failover",
-		value: failover,
-	}
-}
-
-// NewResourceMetaFailoverFromTcpUdp for TCP/DUP failover
-func NewResourceMetaFailoverFromTcpUdp(failover FailoverTcpUdpCheck) ResourceMeta {
-	return ResourceMeta{
-		name:  "failover",
-		value: failover,
-	}
-}
-
-// NewResourceMetaFailoverFromIcmp for ICMP failover
-func NewResourceMetaFailoverFromIcmp(failover FailoverIcmpCheck) ResourceMeta {
-	return ResourceMeta{
-		name:  "failover",
-		value: failover,
 	}
 }
 


### PR DESCRIPTION
previously just failover, wrong assumption that resource.meta is for failover (there is but for uuid), apparently it's rrset.meta.

changes:
- add other rrset.meta based on apidoc
- rename resourceMetaFailover to rrsetMetaFailover 
- add a method on rrset so can do method chaining