### PR TITLE
meta-ip should validate by cidr

### DIFF
--- a/client_dto.go
+++ b/client_dto.go
@@ -493,10 +493,10 @@ func (rm ResourceMeta) Valid() error {
 // NewResourceMetaIP for ip meta
 func NewResourceMetaIP(ips ...string) ResourceMeta {
 	for _, v := range ips {
-		ip := net.ParseIP(v)
-		if ip == nil {
+		_, _, err := net.ParseCIDR(v)
+		if err != nil {
 			// nolint: goerr113
-			return ResourceMeta{validErr: fmt.Errorf("wrong ip")}
+			return ResourceMeta{validErr: fmt.Errorf("wrong ip: %v", err)}
 		}
 	}
 	return ResourceMeta{


### PR DESCRIPTION
context: on the gui it's valid to use CIDR
![image](https://github.com/G-Core/gcore-dns-sdk-go/assets/1061610/79b9554c-6c9d-4fcd-83c9-a83bce3e3d99)
